### PR TITLE
Implement dark mode toggle

### DIFF
--- a/app/src/app/app.scss
+++ b/app/src/app/app.scss
@@ -2,7 +2,36 @@
 @use "../assets/styles/variables" as *;
 @use "../assets/styles/_reset.css";
 
+:root {
+  --color-primary: #ff8c00;
+  --color-primary-dark: #e56b00;
+  --color-secondary: #0057b8;
+  --color-accent: #ffc107;
+  --color-bg: #f9fafc;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f5f5f5;
+  --color-surface-hover: #f0f0f0;
+  --color-border: #e0e0e0;
+  --color-text: #212121;
+  --color-text-muted: #555555;
+  --color-link-hover: rgba(255, 140, 0, 0.1);
+}
+
 body {
   font-family: "Englebert", cursive;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+body.dark-mode {
+  color-scheme: dark;
+  --color-bg: #121212;
+  --color-surface: #1e1e1e;
+  --color-surface-alt: #242424;
+  --color-surface-hover: #2a2a2a;
+  --color-border: #333333;
+  --color-text: #f5f5f5;
+  --color-text-muted: #cccccc;
+  --color-link-hover: rgba(255, 140, 0, 0.25);
 }
 

--- a/app/src/app/features/list/list.scss
+++ b/app/src/app/features/list/list.scss
@@ -100,11 +100,11 @@
 
     // Zebra-Striping
     &:nth-child(odd) {
-      background: color.adjust($color-surface, $lightness: 2%);
+      background: $color-surface-alt;
     }
 
     &:hover {
-      background: color.adjust($color-surface, $lightness: 5%);
+      background: $color-surface-hover;
       box-shadow: $shadow-md;
     }
 

--- a/app/src/app/shared/layout/header.html
+++ b/app/src/app/shared/layout/header.html
@@ -10,6 +10,9 @@
       Menü
     </button>
   </nav>
+  <button class="theme-toggle" (click)="toggleDarkMode()" aria-label="Dark Mode umschalten">
+    <span class="material-icons">{{ darkMode ? 'light_mode' : 'dark_mode' }}</span>
+  </button>
 </header>
 
 <ng-template #mainMenu>

--- a/app/src/app/shared/layout/header.scss
+++ b/app/src/app/shared/layout/header.scss
@@ -18,4 +18,14 @@
   .menu-bar {
     position: relative;
   }
+
+  .theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.5rem;
+    color: $color-text;
+    display: flex;
+    align-items: center;
+  }
 }

--- a/app/src/app/shared/layout/header.ts
+++ b/app/src/app/shared/layout/header.ts
@@ -1,5 +1,5 @@
 import { CdkMenuModule } from '@angular/cdk/menu';
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-header',
@@ -10,4 +10,10 @@ import { Component, Input } from '@angular/core';
 })
 export class HeaderComponent {
   protected title = 'wiewarm';
+  protected darkMode = false;
+
+  toggleDarkMode() {
+    this.darkMode = !this.darkMode;
+    document.body.classList.toggle('dark-mode', this.darkMode);
+  }
 }

--- a/app/src/assets/styles/_menu.scss
+++ b/app/src/assets/styles/_menu.scss
@@ -16,7 +16,7 @@
   @include focus-ring;
 
   &:hover {
-    background: color.adjust($color-primary, $lightness: -10%);
+    background: $color-primary-dark;
     box-shadow: $shadow-md;
   }
 }
@@ -41,7 +41,7 @@
 
     &:hover,
     &:focus {
-      background: color.adjust($color-surface, $lightness: 5%);
+      background: $color-surface-hover;
     }
   }
 }

--- a/app/src/assets/styles/_variables.scss
+++ b/app/src/assets/styles/_variables.scss
@@ -4,19 +4,21 @@
 // =============================================================================
 
 // 1. Colors (WCAG AA+)
-$color-primary: #ff8c00 !default; // Brand Orange
-$color-primary-dark: #e56b00 !default;
-$color-secondary: #0057b8 !default; // Blau
-$color-accent: #ffc107 !default; // Gelb-Akzent
+$color-primary: var(--color-primary) !default; // Brand Orange
+$color-primary-dark: var(--color-primary-dark) !default;
+$color-secondary: var(--color-secondary) !default; // Blau
+$color-accent: var(--color-accent) !default; // Gelb-Akzent
 
-$color-bg: #f9fafc !default; // Seiten-Hintergrund
-$color-surface: #ffffff !default; // Karten, Panels
-$color-border: #e0e0e0 !default;
+$color-bg: var(--color-bg) !default; // Seiten-Hintergrund
+$color-surface: var(--color-surface) !default; // Karten, Panels
+$color-surface-alt: var(--color-surface-alt) !default;
+$color-surface-hover: var(--color-surface-hover) !default;
+$color-border: var(--color-border) !default;
 
-$color-text: #212121 !default; // Haupttext
-$color-text-muted: #555555 !default; // Untertext
-$color-link: $color-primary !default;
-$color-link-hover: rgba($color-primary, 0.1) !default;
+$color-text: var(--color-text) !default; // Haupttext
+$color-text-muted: var(--color-text-muted) !default; // Untertext
+$color-link: var(--color-primary) !default;
+$color-link-hover: var(--color-link-hover) !default;
 
 // Tables
 $color-table-header-bg: $color-surface !default;

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -13,6 +13,10 @@
       rel="stylesheet"
       type="text/css"
     />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
     <!-- TODO: Google tag (gtag.js) -->
     <!-- TODO: Robots -->
   </head>


### PR DESCRIPTION
## Summary
- add CSS custom properties for colors
- implement dark mode overrides
- add toggle button in header with Material icons
- style theme switch and item hover colors
- include Material Icons font

## Testing
- `npm test` *(fails: No inputs were found)*
- `npm run build` *(fails: 403 when inlining fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68473b6f0a848325b39c5c5ca4b0b6f8