### PR TITLE
Add detail page for Badis

### DIFF
--- a/app/src/app/app.routes.ts
+++ b/app/src/app/app.routes.ts
@@ -1,10 +1,10 @@
 import { Routes } from '@angular/router';
 import { ListComponent } from './features/list/list';
 import { AccordionComponent } from './features/accordion/accordion';
+import { BadDetailComponent } from './features/bad-detail/bad-detail';
 
 export const routes: Routes = [
   { path: '', component: AccordionComponent },
   // { path: 'list', component: ListComponent },
-
-  // { path: 'badi/:id', component: BadDetail },
+  { path: 'badi/:id', component: BadDetailComponent },
 ];

--- a/app/src/app/features/accordion/accordion.html
+++ b/app/src/app/features/accordion/accordion.html
@@ -76,7 +76,9 @@
           [attr.id]="'acc-body-' + i"
           [attr.aria-labelledby]="'acc-header-' + i"
         >
-          <div class="accordion-body-left"></div>
+          <div class="accordion-body-left">
+            <a [routerLink]="['/badi', item.badid_text]" class="detail-link">Details</a>
+          </div>
           <div class="accordion-body-right">
             <div class="time-label">Aktualisiert: {{ item.date_pretty }}</div>
           </div>

--- a/app/src/app/features/accordion/accordion.scss
+++ b/app/src/app/features/accordion/accordion.scss
@@ -149,6 +149,15 @@
   .accordion-body-left {
     display: flex;
     flex-direction: column;
+    .detail-link {
+      color: $color-link;
+      text-decoration: none;
+      margin-bottom: $space-2;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
   .accordion-body-right {
     display: flex;

--- a/app/src/app/features/accordion/accordion.ts
+++ b/app/src/app/features/accordion/accordion.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, computed, resource, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CdkAccordionModule } from '@angular/cdk/accordion';
+import { RouterModule } from '@angular/router';
 import { BadItem } from 'src/app/shared/interfaces/bad-item.interface';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 
@@ -9,7 +10,13 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
   selector: 'app-accordion',
   templateUrl: './accordion.html',
   styleUrl: './accordion.scss',
-  imports: [CommonModule, FormsModule, CdkAccordionModule, ScrollingModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    CdkAccordionModule,
+    ScrollingModule,
+    RouterModule,
+  ],
 })
 export class AccordionComponent {
   private readonly BAD_ITEM_URL =

--- a/app/src/app/features/bad-detail/bad-detail.html
+++ b/app/src/app/features/bad-detail/bad-detail.html
@@ -1,0 +1,32 @@
+<div class="detail">
+  <a routerLink="/" class="back-link">&larr; Zurück</a>
+  @if(detailResource.isLoading()) {
+  <div class="status" role="status">Laden…</div>
+  } @else if(detailResource.error()) {
+  <div class="status error" role="alert">
+    Fehler beim Laden: {{ detailResource.error()?.message }}
+  </div>
+  } @else if(detailResource.value() as detail) {
+  <h2>{{ detail.badname }}, {{ detail.plz }} {{ detail.ort }}</h2>
+  <div class="address">
+    {{ detail.adresse1 }}<br />
+    {{ detail.adresse2 }}
+  </div>
+  <div class="contact">
+    {{ detail.telefon }}<br />
+    {{ detail.email }}<br />
+    {{ detail.www }}
+  </div>
+  <div class="info" [innerHTML]="detail.info"></div>
+  <h3>Becken</h3>
+  <ul>
+    @for(pool of poolEntries(detail); track pool.beckenid) {
+    <li>
+      <strong>{{ pool.beckenname }}:</strong>
+      {{ pool.temp != null ? pool.temp + '°C' : '—' }} – {{ pool.status }}
+      <span class="date">{{ pool.date_pretty }}</span>
+    </li>
+    }
+  </ul>
+  }
+</div>

--- a/app/src/app/features/bad-detail/bad-detail.scss
+++ b/app/src/app/features/bad-detail/bad-detail.scss
@@ -1,0 +1,19 @@
+@use "../../../assets/styles/variables" as *;
+.detail {
+  padding: 1rem;
+}
+
+.status {
+  padding: 1rem;
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: $color-link;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/app/src/app/features/bad-detail/bad-detail.ts
+++ b/app/src/app/features/bad-detail/bad-detail.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { BadDetailResourceService } from 'src/app/shared/services/bad-detail.service';
+import { BadDetail, BadDetailPool } from 'src/app/shared/interfaces/bad-detail.interface';
+
+@Component({
+  selector: 'app-bad-detail',
+  templateUrl: './bad-detail.html',
+  styleUrl: './bad-detail.scss',
+  imports: [CommonModule],
+})
+export class BadDetailComponent {
+  private readonly id = this.route.snapshot.paramMap.get('id') ?? '';
+  readonly detailResource = this.detailService.getDetailResource(this.id);
+
+  constructor(
+    private route: ActivatedRoute,
+    private detailService: BadDetailResourceService,
+  ) {}
+
+  poolEntries(detail: BadDetail | null | undefined): BadDetailPool[] {
+    return detail?.becken ? Object.values(detail.becken) : [];
+  }
+}

--- a/app/src/app/shared/interfaces/bad-detail.interface.ts
+++ b/app/src/app/shared/interfaces/bad-detail.interface.ts
@@ -1,0 +1,24 @@
+export interface BadDetailPool {
+  beckenid: number;
+  beckenname: string;
+  typ: string;
+  status: string;
+  date_pretty: string;
+  temp: number | null;
+}
+
+export interface BadDetail {
+  badname: string;
+  plz: string;
+  ort: string;
+  adresse1?: string;
+  adresse2?: string;
+  telefon?: string;
+  email?: string;
+  www?: string;
+  zeiten?: string;
+  preise?: string;
+  info?: string;
+  becken?: Record<string, BadDetailPool>;
+  [key: string]: unknown;
+}

--- a/app/src/app/shared/services/bad-detail.service.ts
+++ b/app/src/app/shared/services/bad-detail.service.ts
@@ -1,0 +1,17 @@
+import { Injectable, resource } from '@angular/core';
+import { BadDetail } from '../interfaces/bad-detail.interface';
+
+@Injectable({ providedIn: 'root' })
+export class BadDetailResourceService {
+  private readonly apiBase = 'https://beta.wiewarm.ch/api/v1/bad/';
+
+  getDetailResource(id: string) {
+    return resource<BadDetail, unknown>({
+      loader: ({ abortSignal }) =>
+        fetch(this.apiBase + id, { signal: abortSignal }).then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json() as Promise<BadDetail>;
+        }),
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `BadDetail` types and a fetching service
- add a new `BadDetailComponent` for `/badi/:id` route
- link from accordion items to the new detail page
- style new detail link and page

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a19e80b4832581b411d23492e80b